### PR TITLE
minor improvements to install.md

### DIFF
--- a/docs_src/src/pages/install.md
+++ b/docs_src/src/pages/install.md
@@ -2,23 +2,23 @@ import Details from '@INCLUDES/Details.svelte';
 
 # Installation
 
-You have two ways to start working with `chota` and `svelte-chota`. Instructions are applieble for official [template](https://github.com/sveltejs/template).
+You have two ways to start working with `chota` and `svelte-chota`. These instructions apply to the official [svelte template](https://github.com/sveltejs/template).
 
 
 <Details title="a. Import CSS file in your root component"
     comment="Recommended way"
 >
 
-1.&nbsp;You should install two packages:
+1.&nbsp;Install two node packages for development:
 
 * `chota` - css framework itself
 * `svelte-chota` - Svelte components for chota
 
-```shell
-$ npm install -D chota svelte-chota
+```terminal
+$ npm install --save-dev chota svelte-chota
 ```
 
-2.&nbsp;Then open you root app file (usually `App.svelte`) and add the `chota` import at the top of a `<script>` block.
+2.&nbsp;Open your root component file (usually `App.svelte`) and add the `chota` import at the top of a `<script>` block.
 
 ```html
 <script>
@@ -32,15 +32,15 @@ $ npm install -D chota svelte-chota
 
 <Details
     title="c. Import from CDN"
-    comment="The easiest way"
+    comment="Easiest way"
 >
 
-Another way to import `chota` without Rollup's config changing is using CDN. In this case internet connection required for users of your app.
+Another way to import `chota` without Rollup's config changing is using CDN. In this case an internet connection is required for users of your app.
 
-1.&nbsp;Install `svelte-chota`  
+1.&nbsp;Install `svelte-chota` for production:
 
-```shell
-$ npm install --save svelte-chota
+```terminal
+$ npm install --save-prod svelte-chota
 ```
 
 2.&nbsp;Import styles from chota's CDN in the `style` block of the your `App.svelte`.
@@ -51,5 +51,5 @@ $ npm install --save svelte-chota
 </style>
 ```
 
-> This way is ideal for using with sandboxes. See example on the [REPL](https://svelte.dev/repl/23f96be8ef424e12b584f9ed00761e88?version=3.12.1)
+> This way is ideal for use in sandboxes. See example on the [REPL](https://svelte.dev/repl/23f96be8ef424e12b584f9ed00761e88)
 </Details>


### PR DESCRIPTION
- corrected a spelling error in 'applicable' (line 5), but then simplified the sentence and tweaked some grammar throughout (subjective, but i think it reads better now)
- removed the `version` query param from the sandbox example link (example version `3.12.1` is broken on the REPL site, but removing the version tag loads the current version--`3.32.3`, which works)
- used long-form args with `npm install` to be more descriptive