### PR TITLE
show how to swap content on tab change

### DIFF
--- a/docs_src/src/pages/components/tabs.md
+++ b/docs_src/src/pages/components/tabs.md
@@ -3,18 +3,36 @@
 ### Simple usage
 
 ```example
+<style>
+ p { padding: 2em; background-color: #ddd; }
+</style>
 <script>
  import { Tabs,Tab } from 'svelte-chota';
  let active_tab = 0;
 </script>
 
 <Tabs bind:active={active_tab}>
+    <Tab>Tab0</Tab>
     <Tab>Tab1</Tab>
     <Tab>Tab2</Tab>
-    <Tab>Tab3</Tab>
 </Tabs>
 
-Current active tab: {active_tab}
+<i>current active tab: <b>{active_tab}</b></i>
+
+{#if active_tab == 0}
+<p>	
+content for Tab0
+{/if}
+
+{#if active_tab == 1}
+<p>	
+Tab1 content here
+{/if}
+
+{#if active_tab == 2}
+<p>	
+here is content for Tab2
+{/if}
 ```
 
 


### PR DESCRIPTION
i'm not sure this is the canonical method for revealing content associated with a tab, but i think the example should demonstrate how to do that.

i've tested the approach submitted here with an example on the svelte REPL:
https://svelte.dev/repl/6c5f9a70af7d45989fae0b162c8ac15d