### PR TITLE
Update Modal.svelte

### DIFF
--- a/cmp/Modal.svelte
+++ b/cmp/Modal.svelte
@@ -11,7 +11,7 @@
 
 {#if open}
 <div class="container" transition:fade={{ duration: 200 }}>
-    <div class="background" on:click={e => open=false}/>
+    <div class="background" on:click={e => open=false} on:keyup={e => open=false}/>
     <div class:modal={1} use:events {...$$restProps}><slot></slot></div>
 </div>
 {/if}


### PR DESCRIPTION
To fix (!) Plugin svelte: A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.