### PR TITLE
fix `getEventsAction`: `this` is undefined

### DIFF
--- a/cmp/utils.js
+++ b/cmp/utils.js
@@ -12,7 +12,9 @@ export function getEventsAction() {
 
       events.forEach(
           event => listeners.push(
-              listen(node, event, e =>  bubble(component, e))
+              listen(node, event, function(e) {
+                 bubble.call(this, component, e);
+              })
             )
         );
   


### PR DESCRIPTION
```svelte
<button
  on:click={function () {
    console.log(this) // HTMLButtonElement, but if it were component with action, `this` will be undefined
  }}
>
  Button
</button>
```